### PR TITLE
Fix

### DIFF
--- a/index.html
+++ b/index.html
@@ -16,6 +16,7 @@
 <body>
   <div id="root"></div>
   <script src="https://unpkg.com/systemjs@6.8.3/dist/system.js"></script>
+  <script src="https://unpkg.com/systemjs@6.8.3/dist/extras/amd.js"></script>
   <script src="https://unpkg.com/systemjs@6.8.3/dist/extras/named-register.js"></script>
   <!-- <script src="https://unpkg.com/react@17.0.2/umd/react.development.js"></script> -->
   <!-- <script src="https://unpkg.com/react-dom@17.0.2/umd/react-dom.development.js"></script> -->

--- a/index.js
+++ b/index.js
@@ -1,4 +1,8 @@
 // System.set('app:react', window.React)
-System.import('test').then(m => {
-  ReactDOM.render(React.createElement(m.default, null, null), document.getElementById('root'))
+Promise.all([
+  System.import('react'),
+  System.import('react-dom'),
+  System.import('test')
+]).then(([React, ReactDOM, Test]) => {
+  ReactDOM.render(React.createElement(Test.default, null, null), document.getElementById('root'))
 })


### PR DESCRIPTION
It's better to load React and ReactDOM as AMD modules, not global variables. Adding the amd.js extra removes the error for registration[1], which was ultimately caused by complex race conditions in both the named-register and global.js systemjs extras.